### PR TITLE
I've added the initial test suite structure and placeholder tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "numaxlab/geslib-files": "^1.0@beta"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^11.5",
+        "mockery/mockery": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,5 +41,6 @@
             "email": "noa@numax.org"
         }
     ],
-    "minimum-stability": "beta"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/Geslib/ArticleAuthorCommandTest.php
+++ b/tests/Geslib/ArticleAuthorCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace NumaxLab\Lunar\Geslib\Tests\Geslib;
+
+use NumaxLab\Lunar\Geslib\Geslib\ArticleAuthorCommand;
+use NumaxLab\Lunar\Geslib\Tests\TestCase;
+
+class ArticleAuthorCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function article_author_command_exists_and_can_be_instantiated()
+    {
+        $this->assertTrue(class_exists(ArticleAuthorCommand::class));
+
+        $command = new ArticleAuthorCommand();
+
+        $this->assertInstanceOf(ArticleAuthorCommand::class, $command);
+    }
+}

--- a/tests/Geslib/EditorialCommandTest.php
+++ b/tests/Geslib/EditorialCommandTest.php
@@ -5,7 +5,7 @@ namespace NumaxLab\Lunar\Geslib\Tests;
 use NumaxLab\Geslib\Lines\Action;
 use NumaxLab\Geslib\Lines\Editorial;
 use NumaxLab\Lunar\Geslib\Geslib\EditorialCommand;
-use PHPUnit\Framework\TestCase;
+use NumaxLab\Lunar\Geslib\Tests\TestCase;
 
 class EditorialCommandTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NumaxLab\Lunar\Geslib\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    // You can add common setup, teardown, or helper methods here
+}


### PR DESCRIPTION
Here's what I did:
1. I initialized the testing environment by creating a base TestCase.
2. I attempted to create tests for ArticleAuthorCommand and ArticleCommand.
3. I encountered significant difficulties instantiating `final` classes with private constructors from the `numaxlab/geslib-files` vendor package (e.g., `Action`, `ArticleAuthor`, `Article`). This was due to the inability to inspect the vendor code to find the correct factory methods or enum cases.
4. I created a placeholder test for `ArticleAuthorCommand` to acknowledge its existence while bypassing the instantiation issues.
5. I was actively trying to find a workaround for `ArticleCommand` (e.g., using PHPUnit's `createMock` or Reflection) when I paused my work.

Currently, the main challenge was the inability to create instances of `numaxLab/Geslib/Lines/Action` and other related classes from the `geslib-files` library. This prevented full unit testing of commands that depend on these line objects.

Your recent feedback provided a link to the vendor library's tests, revealing a `fromLine` static method that should resolve this instantiation blocker. This information will be crucial for me to make further progress.

The code I've worked on includes:
- `tests/TestCase.php`
- `tests/Geslib/EditorialCommandTest.php` (updated to use the base TestCase)
- `tests/Geslib/ArticleAuthorCommandTest.php` (placeholder test)